### PR TITLE
fix(home): improve mobile @-row layout

### DIFF
--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -17,8 +17,8 @@
 <hr>
 
 <div class="list">
-<p class="list"><strong class="role-name" data-i18n="bs_degree">B.S. CS (Artificial Intelligence)</strong><span data-i18n="at_stanford_bs">@ Stanford</span></p>
-<p class="list"><strong class="role-name" data-i18n="ms_degree">M.S. CS (AI + Robotics)</strong><span data-i18n="at_stanford_ms">@ Stanford</span></p>
+<p class="list at-row"><strong class="role-name" data-i18n="bs_degree">B.S. CS (Artificial Intelligence)</strong><span class="at-value" data-i18n="at_stanford_bs">@ Stanford</span></p>
+<p class="list at-row"><strong class="role-name" data-i18n="ms_degree">M.S. CS (AI + Robotics)</strong><span class="at-value" data-i18n="at_stanford_ms">@ Stanford</span></p>
 
 <!--
 <p class="list"><strong>Robotics Intern</strong> &nbsp @ Neuralink</p>
@@ -32,14 +32,14 @@
 <!--
 
 -->
-<p class="list"><span class="role-name" data-i18n="mars_rovers">Mars Rovers</span><span data-i18n="at_nasa_jpl">@ NASA Jet Propulsion Laboratory</span></p>
-<p class="list"><span class="role-name" data-i18n="robotics">Robotics</span><span data-i18n="at_field_ai">@ Field AI</span></p>
-<p class="list"><span class="role-name" data-i18n="ai_research">AI Research</span><span data-i18n="at_apple">@ Apple</span></p>
-<p class="list"><span class="role-name" data-i18n="cofounder_drones">Co-Founder + Drones</span><span data-i18n="at_foundational">@ Foundational Machines</span></p>
-<p class="list"><span class="role-name" data-i18n="cofounder_rovers">Co-founder + Moon Rovers</span><span data-i18n="at_daelus">@ Daelus Space</span></p>
-<p class="list"><span class="role-name" data-i18n="ai_consulting">AI Consulting</span><span data-i18n="at_franca">@ Franca.ai</span></p>
-<p class="list"><span class="role-name" data-i18n="quant_research">Quantitative Research</span><span data-i18n="at_millennium">@ Millennium Management LLC</span></p>
-<p class="list"><span class="role-name" data-i18n="contech_investing">Construction Tech Investing</span><span data-i18n="at_takeoff">@ Takeoff Capital</span></p>
+<p class="list at-row"><span class="role-name" data-i18n="mars_rovers">Mars Rovers</span><span class="at-value" data-i18n="at_nasa_jpl">@ NASA Jet Propulsion Laboratory</span></p>
+<p class="list at-row"><span class="role-name" data-i18n="robotics">Robotics</span><span class="at-value" data-i18n="at_field_ai">@ Field AI</span></p>
+<p class="list at-row"><span class="role-name" data-i18n="ai_research">AI Research</span><span class="at-value" data-i18n="at_apple">@ Apple</span></p>
+<p class="list at-row"><span class="role-name" data-i18n="cofounder_drones">Co-Founder + Drones</span><span class="at-value" data-i18n="at_foundational">@ Foundational Machines</span></p>
+<p class="list at-row"><span class="role-name" data-i18n="cofounder_rovers">Co-founder + Moon Rovers</span><span class="at-value" data-i18n="at_daelus">@ Daelus Space</span></p>
+<p class="list at-row"><span class="role-name" data-i18n="ai_consulting">AI Consulting</span><span class="at-value" data-i18n="at_franca">@ Franca.ai</span></p>
+<p class="list at-row"><span class="role-name" data-i18n="quant_research">Quantitative Research</span><span class="at-value" data-i18n="at_millennium">@ Millennium Management LLC</span></p>
+<p class="list at-row"><span class="role-name" data-i18n="contech_investing">Construction Tech Investing</span><span class="at-value" data-i18n="at_takeoff">@ Takeoff Capital</span></p>
 
 <!--
 <p class="list">Robotics Software @ Invisio-AI</p>
@@ -51,8 +51,8 @@
 
 <hr>
 
-<p class="list"><span class="role-name">787-10</span>@ <a href="https://github.com/787-10">github</a></p>
-<p class="list"><span class="role-name">Brian Y. Wu</span>@ <a href="https://www.linkedin.com/in/brianywu/">linkedin</a></p>
+<p class="list at-row"><span class="role-name">787-10</span><span class="at-value">@ <a href="https://github.com/787-10">github</a></span></p>
+<p class="list at-row"><span class="role-name">Brian Y. Wu</span><span class="at-value">@ <a href="https://www.linkedin.com/in/brianywu/">linkedin</a></span></p>
 
 
 </br>
@@ -88,6 +88,8 @@
       el.style.display = 'inline-block';
       el.style.width = 'auto';
     });
+    // Mobile rows stack, so each label should keep its natural width.
+    if (window.matchMedia('(max-width: 575.98px)').matches) return;
     // Find max natural width
     var maxWidth = 0;
     names.forEach(function(el) {
@@ -128,6 +130,7 @@
   };
 
   alignRoles();
+  window.addEventListener('resize', alignRoles);
 })();
 </script>
 

--- a/templates/layout.html.tera
+++ b/templates/layout.html.tera
@@ -46,6 +46,33 @@
           margin-bottom: 0px;
       }
 
+      .at-row {
+        display: flex;
+        align-items: baseline;
+      }
+      .at-row .role-name {
+        flex: 0 0 auto;
+      }
+      .at-row .at-value {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+
+      @media (max-width: 575.98px) {
+        .at-row {
+          display: block;
+          margin-bottom: 0.5rem;
+        }
+        .at-row .role-name,
+        .at-row .at-value {
+          display: block;
+          width: auto !important;
+        }
+        .at-row .at-value {
+          padding-left: 1rem;
+        }
+      }
+
       .dark-mode {
         background-color: black;
         color: white;

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Automated tests for website maintenance tools."""
+"""Automated tests for website behavior and maintenance tools."""

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1,0 +1,108 @@
+import html
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHROME = shutil.which("google-chrome") or shutil.which("chromium")
+
+
+def render_index_for_browser(check_mode):
+    layout = (ROOT / "templates" / "layout.html.tera").read_text()
+    index = (ROOT / "templates" / "index.html.tera").read_text()
+    page = re.search(
+        r"{% block page %}(.*){% endblock %}", index, re.DOTALL
+    ).group(1)
+    rendered = re.sub(
+        r"{% block page %}.*?{% endblock %}",
+        page,
+        layout,
+        count=1,
+        flags=re.DOTALL,
+    )
+    rendered = rendered.replace(
+        "</head>",
+        "<style>.container{width:100%;padding:0 15px;margin:0 auto;}</style>"
+        "</head>",
+    )
+    check_script = f"""
+      <script>
+        document.addEventListener('DOMContentLoaded', function() {{
+          requestAnimationFrame(function() {{
+            var rows = Array.from(document.querySelectorAll('.at-row'));
+            var failures = [];
+            if (rows.length !== 12) failures.push('expected 12 rows, got ' + rows.length);
+            rows.forEach(function(row, index) {{
+              var label = row.querySelector('.role-name');
+              var value = row.querySelector('.at-value');
+              if (!label || !value) {{
+                failures.push('row ' + index + ' lacks structured fields');
+                return;
+              }}
+              var rowBox = row.getBoundingClientRect();
+              var labelBox = label.getBoundingClientRect();
+              var valueBox = value.getBoundingClientRect();
+              if ('{check_mode}' === 'mobile') {{
+                if (valueBox.top < labelBox.bottom - 1) failures.push('row ' + index + ' is not stacked');
+                if (row.scrollWidth > row.clientWidth || valueBox.right > rowBox.right + 1) failures.push('row ' + index + ' overflows');
+              }} else {{
+                if (valueBox.top >= labelBox.bottom) failures.push('row ' + index + ' lost desktop alignment');
+              }}
+            }});
+            var result = document.createElement('pre');
+            result.id = 'layout-test-result';
+            result.textContent = failures.length ? 'FAIL: ' + failures.join('; ') : 'PASS';
+            document.body.appendChild(result);
+          }});
+        }});
+      </script>
+    """
+    return rendered.replace("</body>", check_script + "</body>")
+
+
+@unittest.skipUnless(CHROME, "headless Chrome is required for layout tests")
+class ResponsiveAtRowTests(unittest.TestCase):
+    def assert_layout(self, mode, width, height):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            page_path = temp_path / "index.html"
+            page_path.write_text(render_index_for_browser(mode))
+            result = subprocess.run(
+                [
+                    CHROME,
+                    "--headless=new",
+                    "--no-sandbox",
+                    "--disable-gpu",
+                    "--disable-dev-shm-usage",
+                    f"--user-data-dir={temp_path / 'profile'}",
+                    "--virtual-time-budget=1000",
+                    f"--window-size={width},{height}",
+                    "--dump-dom",
+                    page_path.as_uri(),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        match = re.search(
+            r'<pre id="layout-test-result">(.*?)</pre>',
+            result.stdout,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match, result.stderr)
+        self.assertEqual(html.unescape(match.group(1)), "PASS")
+
+    def test_at_rows_stack_without_overflow_on_a_phone(self):
+        self.assert_layout("mobile", 390, 844)
+
+    def test_at_rows_remain_aligned_on_desktop(self):
+        self.assert_layout("desktop", 1280, 900)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- structure each active label/@-value pair as a responsive row
- retain aligned same-line rows on desktop
- stack and indent @ values at the Bootstrap mobile breakpoint so organizations receive the full available width
- realign rows after viewport resizes and language changes

## Tests
- uv run python -m unittest discover -v (2 passed)
- headless Chrome geometry checks at 390x844 and 1280x900
- visual screenshot inspection at 390x844
- git diff --check master...HEAD
- cargo test (baseline blocked before these changes by Rocket 0.4's traitobject dependency on current nightly)

Closes #43